### PR TITLE
Fix pubsub healthcheck timeout

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -61,6 +61,9 @@ management:
   endpoint:
     health:
       enabled: true
+  health:
+    pubsub:
+      enabled: false
   metrics:
     tags:
       application: "Notify Service"


### PR DESCRIPTION
# Motivation and Context
Spring actuator healthchecks attempt to read the 'queue depth' of pubsub subscriptions but the service account doesn't have permission, so it fails.

# What has changed
Disabled the actuator healthcheck.

# How to test?
Try it.

# Links
Trello: https://trello.com/c/LvFNl7N6