### PR TITLE
Permit more event versions than just v0.3_RELEASE

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/SmsRequestReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/SmsRequestReceiver.java
@@ -100,7 +100,7 @@ public class SmsRequestReceiver {
     EventHeaderDTO enrichedEventHeader = new EventHeaderDTO();
     enrichedEventHeader.setMessageId(UUID.randomUUID());
     enrichedEventHeader.setCorrelationId(smsRequestHeader.getCorrelationId());
-    enrichedEventHeader.setVersion(Constants.EVENT_SCHEMA_VERSION);
+    enrichedEventHeader.setVersion(Constants.OUTBOUND_EVENT_SCHEMA_VERSION);
     enrichedEventHeader.setChannel(smsRequestHeader.getChannel());
     enrichedEventHeader.setSource(smsRequestHeader.getSource());
     enrichedEventHeader.setOriginatingUser(smsRequestHeader.getOriginatingUser());

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/service/SmsRequestService.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/service/SmsRequestService.java
@@ -96,7 +96,7 @@ public class SmsRequestService {
     eventHeader.setCorrelationId(correlationId);
     eventHeader.setOriginatingUser(originatingUser);
     eventHeader.setDateTime(OffsetDateTime.now(Clock.systemUTC()));
-    eventHeader.setVersion(Constants.EVENT_SCHEMA_VERSION);
+    eventHeader.setVersion(Constants.OUTBOUND_EVENT_SCHEMA_VERSION);
     eventHeader.setMessageId(UUID.randomUUID());
     enrichedSmsFulfilmentEvent.setHeader(eventHeader);
     enrichedSmsFulfilmentEvent.setPayload(new PayloadDTO());

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/utils/Constants.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/utils/Constants.java
@@ -1,7 +1,11 @@
 package uk.gov.ons.ssdc.notifysvc.utils;
 
+import java.util.Set;
+
 public class Constants {
-  public static final String EVENT_SCHEMA_VERSION = "v0.3_RELEASE";
+  public static final String OUTBOUND_EVENT_SCHEMA_VERSION = "v0.3_RELEASE";
+  public static final Set<String> ALLOWED_INBOUND_EVENT_SCHEMA_VERSIONS =
+      Set.of("v0.3_RELEASE", "0.4.0-DRAFT", "0.4.0");
   public static final String SMS_TEMPLATE_UAC_KEY = "__uac__";
   public static final String SMS_TEMPLATE_QID_KEY = "__qid__";
   public static final String SMS_TEMPLATE_SENSITIVE_PREFIX = "__sensitive__.";

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/utils/JsonHelper.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/utils/JsonHelper.java
@@ -1,6 +1,6 @@
 package uk.gov.ons.ssdc.notifysvc.utils;
 
-import static uk.gov.ons.ssdc.notifysvc.utils.Constants.EVENT_SCHEMA_VERSION;
+import static uk.gov.ons.ssdc.notifysvc.utils.Constants.ALLOWED_INBOUND_EVENT_SCHEMA_VERSIONS;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
@@ -17,11 +17,12 @@ public class JsonHelper {
       throw new RuntimeException(e);
     }
 
-    if (!EVENT_SCHEMA_VERSION.equals(event.getHeader().getVersion())) {
+    if (!ALLOWED_INBOUND_EVENT_SCHEMA_VERSIONS.contains((event.getHeader().getVersion()))) {
       throw new RuntimeException(
           String.format(
-              "Incorrect message version. Expected %s but got: %s",
-              EVENT_SCHEMA_VERSION, event.getHeader()));
+              "Unsupported message version. Got %s but RM only supports %s",
+              event.getHeader().getVersion(),
+              String.join(", ", ALLOWED_INBOUND_EVENT_SCHEMA_VERSIONS)));
     }
 
     return event;

--- a/src/test/java/uk/gov/ons/ssdc/notifysvc/testUtils/MessageConstructor.java
+++ b/src/test/java/uk/gov/ons/ssdc/notifysvc/testUtils/MessageConstructor.java
@@ -34,7 +34,7 @@ public class MessageConstructor {
     eventHeaderDTO.setOriginatingUser("test@example.test");
     eventHeaderDTO.setSource("TEST_SOURCE");
     eventHeaderDTO.setChannel("TEST_CHANNEL");
-    eventHeaderDTO.setVersion(Constants.EVENT_SCHEMA_VERSION);
+    eventHeaderDTO.setVersion(Constants.OUTBOUND_EVENT_SCHEMA_VERSION);
 
     eventDTO.setPayload(payloadDTO);
     eventDTO.setHeader(eventHeaderDTO);


### PR DESCRIPTION
# Motivation and Context
We don't quite know what version INT will be sending to us when we meet in integration, so let's be a bit more permsisive.

# What has changed
Allow `0.4.0-DRAFT` and `0.4.0` as versions, as well as `v0.3_RELEASE`.

# How to test?
Wang in some messages with `0.4.0-DRAFT` or `0.4.0` version in the header, and check they're not rejected.

# Links
Trello: https://trello.com/c/i1kSq2Sz