### PR TITLE
Migrate to shared events version 0.5.0 release

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/utils/Constants.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/utils/Constants.java
@@ -3,9 +3,9 @@ package uk.gov.ons.ssdc.notifysvc.utils;
 import java.util.Set;
 
 public class Constants {
-  public static final String OUTBOUND_EVENT_SCHEMA_VERSION = "v0.3_RELEASE";
+  public static final String OUTBOUND_EVENT_SCHEMA_VERSION = "0.5.0";
   public static final Set<String> ALLOWED_INBOUND_EVENT_SCHEMA_VERSIONS =
-      Set.of("v0.3_RELEASE", "0.4.0-DRAFT", "0.4.0", "0.5.0-DRAFT");
+      Set.of("v0.3_RELEASE", "0.4.0-DRAFT", "0.4.0", "0.5.0-DRAFT", "0.5.0", "0.6.0-DRAFT");
   public static final String TEMPLATE_UAC_KEY = "__uac__";
   public static final String TEMPLATE_QID_KEY = "__qid__";
   public static final String TEMPLATE_SENSITIVE_PREFIX = "__sensitive__.";


### PR DESCRIPTION
# Motivation and Context
We have released `0.5.0` of the [shared events](https://github.com/ONSdigital/ssdc-shared-events) so it's time to bring our microservices in line with that spec.

# What has changed
Changed all the microservices to publish `0.5.0` as the event version in the headers, and do a few other tweaks to meet the specification.

Also, allow some more versions to be sent to us for present and future needs.

# How to test?
Zero regression - ATs should pass.

# Links
Trello: https://trello.com/c/9uTTLrLW