### PR TITLE
934 Use the sample validation email rule for consistency

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/endpoint/EmailFulfilmentEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/endpoint/EmailFulfilmentEndpoint.java
@@ -184,8 +184,10 @@ public class EmailFulfilmentEndpoint {
   }
 
   private void validateEmailAddress(String emailAddress) {
-    if (!emailRequestService.validateEmailAddress(emailAddress)) {
-      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Invalid email address");
+    Optional<String> validationFailure = emailRequestService.validateEmailAddress(emailAddress);
+    if (validationFailure.isPresent()) {
+      String responseMessage = String.format("Invalid email address: %s", validationFailure.get());
+      throw new ResponseStatusException(HttpStatus.BAD_REQUEST, responseMessage);
     }
   }
 

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/service/EmailRequestService.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/service/EmailRequestService.java
@@ -8,11 +8,11 @@ import java.time.OffsetDateTime;
 import java.util.Map;
 import java.util.Optional;
 import java.util.UUID;
-import java.util.regex.Pattern;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import uk.gov.ons.ssdc.common.model.entity.EmailTemplate;
 import uk.gov.ons.ssdc.common.model.entity.Survey;
+import uk.gov.ons.ssdc.common.validation.EmailRule;
 import uk.gov.ons.ssdc.notifysvc.client.UacQidServiceClient;
 import uk.gov.ons.ssdc.notifysvc.model.dto.api.UacQidCreatedPayloadDTO;
 import uk.gov.ons.ssdc.notifysvc.model.dto.event.EmailConfirmation;
@@ -32,6 +32,8 @@ public class EmailRequestService {
   private final UacQidServiceClient uacQidServiceClient;
   private final FulfilmentSurveyEmailTemplateRepository fulfilmentSurveyEmailTemplateRepository;
   private final PubSubHelper pubSubHelper;
+
+  private final EmailRule emailValidationRule = new EmailRule(true);
 
   public EmailRequestService(
       UacQidServiceClient uacQidServiceClient,
@@ -54,11 +56,8 @@ public class EmailRequestService {
         emailTemplate, survey);
   }
 
-  public boolean validateEmailAddress(String emailAddress) {
-    Pattern emailPattern =
-        Pattern.compile(
-            "(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|\"(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21\\x23-\\x5b\\x5d-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])*\")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\\x01-\\x08\\x0b\\x0c\\x0e-\\x1f\\x21-\\x5a\\x53-\\x7f]|\\\\[\\x01-\\x09\\x0b\\x0c\\x0e-\\x7f])+)\\])");
-    return emailPattern.matcher(emailAddress).find();
+  public Optional<String> validateEmailAddress(String emailAddress) {
+    return emailValidationRule.checkValidity(emailAddress);
   }
 
   public void buildAndSendEmailConfirmation(

--- a/src/main/resources/application-dev.yml
+++ b/src/main/resources/application-dev.yml
@@ -1,3 +1,8 @@
+spring:
+  datasource:
+    url: jdbc:postgresql://localhost:15435/rm
+    username: appuser
+    password: postgres
 
 notify:
   base-url: http://notifystub:5000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,9 +7,6 @@ spring:
         size: 10
 
   datasource:
-    url: jdbc:postgresql://localhost:6432/postgres
-    username: postgres
-    password: postgres
     driverClassName: org.postgresql.Driver
     hikari:
       maximumPoolSize: 5

--- a/src/test/java/uk/gov/ons/ssdc/notifysvc/endpoint/EmailFulfilmentEndpointTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/notifysvc/endpoint/EmailFulfilmentEndpointTest.java
@@ -92,7 +92,8 @@ class EmailFulfilmentEndpointTest {
     when(emailRequestService.isEmailTemplateAllowedOnSurvey(
             emailTemplate, testCase.getCollectionExercise().getSurvey()))
         .thenReturn(true);
-    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS)).thenReturn(true);
+    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS))
+        .thenReturn(Optional.empty());
     when(emailRequestService.fetchNewUacQidPairIfRequired(emailTemplate.getTemplate()))
         .thenReturn(Optional.of(newUacQid));
 
@@ -154,7 +155,8 @@ class EmailFulfilmentEndpointTest {
     when(emailRequestService.isEmailTemplateAllowedOnSurvey(
             emailTemplate, testCase.getCollectionExercise().getSurvey()))
         .thenReturn(true);
-    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS)).thenReturn(true);
+    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS))
+        .thenReturn(Optional.empty());
     when(emailRequestService.fetchNewUacQidPairIfRequired(emailTemplate.getTemplate()))
         .thenReturn(Optional.of(newUacQid));
 
@@ -213,7 +215,8 @@ class EmailFulfilmentEndpointTest {
     when(emailRequestService.isEmailTemplateAllowedOnSurvey(
             emailTemplate, testCase.getCollectionExercise().getSurvey()))
         .thenReturn(true);
-    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS)).thenReturn(true);
+    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS))
+        .thenReturn(Optional.empty());
     when(emailRequestService.fetchNewUacQidPairIfRequired(emailTemplate.getTemplate()))
         .thenReturn(Optional.empty());
 
@@ -272,7 +275,8 @@ class EmailFulfilmentEndpointTest {
         .thenReturn(true);
     when(emailRequestService.fetchNewUacQidPairIfRequired(emailTemplate.getTemplate()))
         .thenReturn(Optional.of(newUacQid));
-    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS)).thenReturn(true);
+    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS))
+        .thenReturn(Optional.empty());
 
     // Simulate an error when we attempt to send the email
     when(notificationClientApi.sendEmail(any(), any(), any(), any()))
@@ -335,7 +339,9 @@ class EmailFulfilmentEndpointTest {
             emailTemplate, testCase.getCollectionExercise().getSurvey()))
         .thenReturn(true);
     when(emailRequestService.validateEmailAddress(invalidEmailAddress))
-        .thenReturn(false); // TODO how did this pass without this mock?
+        .thenReturn(
+            Optional.of(
+                "Mock email address is invalid")); // TODO how did this pass without this mock?
 
     RequestDTO emailFulfilmentRequest =
         buildEmailFulfilmentRequest(
@@ -348,7 +354,7 @@ class EmailFulfilmentEndpointTest {
                 .content(objectMapper.writeValueAsBytes(emailFulfilmentRequest))
                 .contentType(MediaType.APPLICATION_JSON))
         .andExpect(status().isBadRequest())
-        .andExpect(jsonPath("error", is("Invalid email address")))
+        .andExpect(jsonPath("error", is("Invalid email address: Mock email address is invalid")))
         .andExpect(handler().handlerType(EmailFulfilmentEndpoint.class));
 
     // Then
@@ -399,7 +405,8 @@ class EmailFulfilmentEndpointTest {
     when(emailRequestService.isEmailTemplateAllowedOnSurvey(
             emailTemplate, testCase.getCollectionExercise().getSurvey()))
         .thenReturn(true);
-    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS)).thenReturn(true);
+    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS))
+        .thenReturn(Optional.empty());
 
     // When validated, then no exception is thrown
     emailFulfilmentEndpoint.validateRequestAndFetchEmailTemplate(

--- a/src/test/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestReceiverTest.java
@@ -74,7 +74,8 @@ class EmailRequestReceiverTest {
     when(caseRepository.existsById(testCase.getId())).thenReturn(true);
     when(emailRequestService.fetchNewUacQidPairIfRequired(emailTemplate.getTemplate()))
         .thenReturn(Optional.of(newUacQidCreated));
-    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS)).thenReturn(true);
+    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS))
+        .thenReturn(Optional.empty());
 
     EventDTO emailRequestEvent = buildEventDTO(emailRequestEnrichedTopic);
     EmailRequest emailRequest = new EmailRequest();
@@ -137,7 +138,8 @@ class EmailRequestReceiverTest {
     when(caseRepository.existsById(testCase.getId())).thenReturn(true);
     when(emailRequestService.fetchNewUacQidPairIfRequired(emailTemplate.getTemplate()))
         .thenReturn(Optional.of(newUacQidCreated));
-    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS)).thenReturn(true);
+    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS))
+        .thenReturn(Optional.empty());
 
     EventDTO emailRequestEvent = buildEventDTO(emailRequestEnrichedTopic);
     EmailRequest emailRequest = new EmailRequest();
@@ -195,7 +197,8 @@ class EmailRequestReceiverTest {
     when(caseRepository.existsById(testCase.getId())).thenReturn(true);
     when(emailRequestService.fetchNewUacQidPairIfRequired(emailTemplate.getTemplate()))
         .thenReturn(Optional.empty());
-    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS)).thenReturn(true);
+    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS))
+        .thenReturn(Optional.empty());
 
     EventDTO emailRequestEvent = buildEventDTO(emailRequestEnrichedTopic);
     EmailRequest emailRequest = new EmailRequest();
@@ -253,7 +256,8 @@ class EmailRequestReceiverTest {
     when(caseRepository.existsById(testCase.getId())).thenReturn(true);
     when(emailRequestService.fetchNewUacQidPairIfRequired(emailTemplate.getTemplate()))
         .thenReturn(Optional.empty());
-    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS)).thenReturn(true);
+    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS))
+        .thenReturn(Optional.empty());
 
     EventDTO emailRequestEvent = buildEventDTO(emailRequestEnrichedTopic);
     EmailRequest emailRequest = new EmailRequest();
@@ -298,7 +302,7 @@ class EmailRequestReceiverTest {
   }
 
   @Test
-  void testReceiveMessageExceptionOnInvalidPhoneNumber() {
+  void testReceiveMessageExceptionOnInvalidEmailAddress() {
     // Given
     Case testCase = new Case();
     testCase.setId(UUID.randomUUID());
@@ -309,7 +313,8 @@ class EmailRequestReceiverTest {
 
     String invalidEmailAddress = "blah";
 
-    when(emailRequestService.validateEmailAddress(invalidEmailAddress)).thenReturn(false);
+    when(emailRequestService.validateEmailAddress(invalidEmailAddress))
+        .thenReturn(Optional.of("Email is invalid"));
 
     EventDTO emailRequestEvent = buildEventDTO(emailRequestEnrichedTopic);
     EmailRequest emailRequest = new EmailRequest();
@@ -347,7 +352,8 @@ class EmailRequestReceiverTest {
 
     when(emailTemplateRepository.findById(emailTemplate.getPackCode()))
         .thenReturn(Optional.of(emailTemplate));
-    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS)).thenReturn(true);
+    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS))
+        .thenReturn(Optional.empty());
     when(caseRepository.existsById(testCase.getId())).thenReturn(false);
 
     EventDTO emailRequestEvent = buildEventDTO(emailRequestEnrichedTopic);
@@ -382,7 +388,8 @@ class EmailRequestReceiverTest {
     newUacQidCreated.setUac(TEST_UAC);
     newUacQidCreated.setQid(TEST_QID);
 
-    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS)).thenReturn(true);
+    when(emailRequestService.validateEmailAddress(VALID_EMAIL_ADDRESS))
+        .thenReturn(Optional.empty());
     when(emailTemplateRepository.findById(emailTemplate.getPackCode()))
         .thenReturn(Optional.empty());
 

--- a/src/test/java/uk/gov/ons/ssdc/notifysvc/service/EmailRequestServiceTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/notifysvc/service/EmailRequestServiceTest.java
@@ -60,12 +60,11 @@ class EmailRequestServiceTest {
         "example@example.com",
         "foo@bar.co.uk",
         "email@subdomain.example.com",
-        "email@123.123.123.123",
         "foo+bar@example.com",
         "1234567890@example.com",
       })
   void testValidateEmailAddressValid(String emailAddress) {
-    assertTrue(emailRequestService.validateEmailAddress(emailAddress));
+    assertThat(emailRequestService.validateEmailAddress(emailAddress)).isEmpty();
   }
 
   @ParameterizedTest
@@ -78,7 +77,7 @@ class EmailRequestServiceTest {
         "@.com",
       })
   void testValidateEmailAddressInvalid(String emailAddress) {
-    assertFalse(emailRequestService.validateEmailAddress(emailAddress));
+    assertThat(emailRequestService.validateEmailAddress(emailAddress)).isPresent();
   }
 
   @Test

--- a/src/test/resources/application-test.yml
+++ b/src/test/resources/application-test.yml
@@ -1,6 +1,8 @@
 spring:
   datasource:
-    url: jdbc:postgresql://localhost:15435/postgres
+    url: jdbc:postgresql://localhost:15435/rm
+    username: appuser
+    password: postgres
 
   cloud:
     gcp:

--- a/src/test/resources/docker-compose.yml
+++ b/src/test/resources/docker-compose.yml
@@ -21,7 +21,7 @@ services:
     external_links:
       - postgres-notify-service-it
     environment:
-      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres-notify-service-it:5432/postgres?sslmode=disable
+      - SPRING_DATASOURCE_URL=jdbc:postgresql://postgres-notify-service-it:5432/rm?sslmode=disable
       - SPRING_PROFILES_ACTIVE=dev
     volumes:
       - ./java_healthcheck:/opt/healthcheck/


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Email addresses were being validated with a different regex to our sample rules, which appears to have slightly different results. The email rule in our sample validation is built to match Notify's own validation, and we use it on our sample, so the same rule should be used here for consistency.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Update email address validation to use existing EmailRule
- Update code to use the optional failure message returned by the EmailRule

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Try sending an email fulfilment to a valid email address with capital letters, it should no longer fail wrongly on the address validation.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://trello.com/c/ebksc1Se/934-notify-service-is-using-a-slightly-different-email-validation-to-the-sample