### PR TITLE
1215 dependabotyml

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "maven"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
# Motivation and Context
Dependabot wasn't doing PR on java repos

# What has changed
Added Dependabot.yml config file for maven

# How to test?
Check it looks ok
Already tested in a separate repo: https://github.com/ONSdigital/ssdc-rm-caseprocessor/pull/183

# Links
https://trello.com/c/rCM6wKZv

# Screenshots (if appropriate):