### PR TITLE
Updating dependabot checks to weekly and major versions only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,10 +3,10 @@ updates:
   - package-ecosystem: "maven"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     ignore:
       - dependency-name: "*"
-        update-types: [ "version-update:semver-patch" ]
+        update-types: [ "version-update:semver-patch", "version-update:semver-minor" ]
     labels:
       - "patch"
       - "dependencies"


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The current config wasn't updated like the other repos so it was still creating PRs daily and was still looking at minor updates. Should be changed to checking weekly and only major updates.
# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Changed dependabot yml to be weekly checked and only major updates
# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Make sure it's similar to the other repos
# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
[Jira](https://jira.ons.gov.uk/browse/SDCSRM-498)
