### PR TITLE
SDCSRM-582 Dependabot Fix Security Labels

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,4 @@ updates:
     labels:
       - "patch"
       - "dependencies"
-    ignore:
-      - dependency-name: "*"
-        update-types: [ "version-update:semver-patch", "version-update:semver-minor", "version-update:semver-major" ]
+    open-pull-requests-limit: 0


### PR DESCRIPTION
# Motivation and Context
Dependabot wasn't adding labels to security updates. This was due to the dependabot config being wrong, as it should be using `open-pull-requests-limit: 0` instead of the `ignore` tag

# What has changed
- Switched from the `ignore` tag to `open-pull-requests-limit: 0`

# How to test?
Check it looks ok

# Links
[Jira SDCSRM-582](https://jira.ons.gov.uk/browse/SDCSRM-582)
[Github Docs](https://docs.github.com/en/code-security/dependabot/dependabot-security-updates/configuring-dependabot-security-updates#overriding-the-default-behavior-with-a-configuration-file)