### PR TITLE
SDCSRM-689 Add email processing debug logs

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestEnrichedReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestEnrichedReceiver.java
@@ -4,6 +4,9 @@ import static uk.gov.ons.ssdc.notifysvc.utils.JsonHelper.convertJsonBytesToEvent
 import static uk.gov.ons.ssdc.notifysvc.utils.PersonalisationTemplateHelper.buildPersonalisationFromTemplate;
 
 import java.util.Map;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
@@ -23,6 +26,8 @@ public class EmailRequestEnrichedReceiver {
 
   @Value("${email-request-enriched-delay}")
   private int emailRequestEnrichedDelay;
+
+  private static final Logger log = LoggerFactory.getLogger(EmailRequestEnrichedReceiver.class);
 
   private final EmailTemplateRepository emailTemplateRepository;
   private final CaseRepository caseRepository;
@@ -44,9 +49,18 @@ public class EmailRequestEnrichedReceiver {
     } catch (InterruptedException e) {
       throw new RuntimeException("Interrupted during throttling delay", e);
     }
+    long startTime = System.currentTimeMillis();
 
     EventDTO event = convertJsonBytesToEvent(message.getPayload());
     EmailRequestEnriched emailRequestEnriched = event.getPayload().getEmailRequestEnriched();
+
+    log.atDebug()
+        .setMessage("Starting processing enriched email request message")
+        .addKeyValue("caseId", emailRequestEnriched.getCaseId())
+        .addKeyValue("packCode", emailRequestEnriched.getPackCode())
+        .addKeyValue("messageId", event.getHeader().getMessageId())
+        .addKeyValue("correlationId", event.getHeader().getCorrelationId());
+
     EmailTemplate emailTemplate =
         emailTemplateRepository
             .findById(emailRequestEnriched.getPackCode())
@@ -85,5 +99,13 @@ public class EmailRequestEnrichedReceiver {
           "Error with Gov Notify when attempting to send email (from enriched email request event)",
           e);
     }
+
+    log.atDebug()
+        .setMessage("Starting processing enriched email request message")
+        .addKeyValue("caseId", emailRequestEnriched.getCaseId())
+        .addKeyValue("packCode", emailRequestEnriched.getPackCode())
+        .addKeyValue("messageId", event.getHeader().getMessageId())
+        .addKeyValue("correlationId", event.getHeader().getCorrelationId())
+        .addKeyValue("processingTimeMillis", System.currentTimeMillis() - startTime);
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestEnrichedReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestEnrichedReceiver.java
@@ -101,7 +101,7 @@ public class EmailRequestEnrichedReceiver {
     }
 
     log.atDebug()
-        .setMessage("Starting processing enriched email request message")
+        .setMessage("Finished processing enriched email request message")
         .addKeyValue("caseId", emailRequestEnriched.getCaseId())
         .addKeyValue("packCode", emailRequestEnriched.getPackCode())
         .addKeyValue("messageId", event.getHeader().getMessageId())

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestEnrichedReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestEnrichedReceiver.java
@@ -4,7 +4,6 @@ import static uk.gov.ons.ssdc.notifysvc.utils.JsonHelper.convertJsonBytesToEvent
 import static uk.gov.ons.ssdc.notifysvc.utils.PersonalisationTemplateHelper.buildPersonalisationFromTemplate;
 
 import java.util.Map;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestEnrichedReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestEnrichedReceiver.java
@@ -58,7 +58,8 @@ public class EmailRequestEnrichedReceiver {
         .addKeyValue("caseId", emailRequestEnriched.getCaseId())
         .addKeyValue("packCode", emailRequestEnriched.getPackCode())
         .addKeyValue("messageId", event.getHeader().getMessageId())
-        .addKeyValue("correlationId", event.getHeader().getCorrelationId());
+        .addKeyValue("correlationId", event.getHeader().getCorrelationId())
+        .log();
 
     EmailTemplate emailTemplate =
         emailTemplateRepository
@@ -105,6 +106,7 @@ public class EmailRequestEnrichedReceiver {
         .addKeyValue("packCode", emailRequestEnriched.getPackCode())
         .addKeyValue("messageId", event.getHeader().getMessageId())
         .addKeyValue("correlationId", event.getHeader().getCorrelationId())
-        .addKeyValue("processingTimeMillis", System.currentTimeMillis() - startTime);
+        .addKeyValue("processingTimeMillis", System.currentTimeMillis() - startTime)
+        .log();
   }
 }

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestReceiver.java
@@ -5,7 +5,6 @@ import static uk.gov.ons.ssdc.notifysvc.utils.JsonHelper.convertJsonBytesToEvent
 import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestReceiver.java
@@ -5,6 +5,9 @@ import static uk.gov.ons.ssdc.notifysvc.utils.JsonHelper.convertJsonBytesToEvent
 import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
@@ -27,6 +30,8 @@ public class EmailRequestReceiver {
 
   @Value("${queueconfig.email-request-enriched-topic}")
   private String emailRequestEnrichedTopic;
+
+  private static final Logger log = LoggerFactory.getLogger(EmailRequestReceiver.class);
 
   private final CaseRepository caseRepository;
   private final EmailTemplateRepository emailTemplateRepository;
@@ -54,9 +59,16 @@ public class EmailRequestReceiver {
 
   @ServiceActivator(inputChannel = "emailRequestInputChannel", adviceChain = "retryAdvice")
   public void receiveMessage(Message<byte[]> message) {
+    long startTime = System.currentTimeMillis();
     EventDTO emailRequestEvent = convertJsonBytesToEvent(message.getPayload());
     EventHeaderDTO emailRequestHeader = emailRequestEvent.getHeader();
     EmailRequest emailRequest = emailRequestEvent.getPayload().getEmailRequest();
+    log.atDebug()
+        .setMessage("Starting processing email request message")
+        .addKeyValue("caseId", emailRequest.getCaseId())
+        .addKeyValue("packCode", emailRequest.getPackCode())
+        .addKeyValue("messageId", emailRequestHeader.getMessageId())
+        .addKeyValue("correlationId", emailRequestHeader.getCorrelationId());
 
     validateEmailAddress(emailRequest.getEmail());
 
@@ -94,6 +106,14 @@ public class EmailRequestReceiver {
     // This enriched message can then safely be retried multiple times without potentially
     // generating and linking more, unnecessary UAC/QID pairs
     pubSubHelper.publishAndConfirm(emailRequestEnrichedTopic, emailRequestEnrichedEvent);
+
+    log.atDebug()
+        .setMessage("Finished processing email request message")
+        .addKeyValue("caseId", emailRequest.getCaseId())
+        .addKeyValue("packCode", emailRequest.getPackCode())
+        .addKeyValue("messageId", emailRequestHeader.getMessageId())
+        .addKeyValue("correlationId", emailRequestHeader.getCorrelationId())
+        .addKeyValue("processingTimeMillis", System.currentTimeMillis() - startTime);
   }
 
   private EventDTO buildEmailRequestEnrichedEvent(

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestReceiver.java
@@ -67,7 +67,8 @@ public class EmailRequestReceiver {
         .addKeyValue("caseId", emailRequest.getCaseId())
         .addKeyValue("packCode", emailRequest.getPackCode())
         .addKeyValue("messageId", emailRequestHeader.getMessageId())
-        .addKeyValue("correlationId", emailRequestHeader.getCorrelationId());
+        .addKeyValue("correlationId", emailRequestHeader.getCorrelationId())
+        .log();
 
     validateEmailAddress(emailRequest.getEmail());
 
@@ -112,7 +113,8 @@ public class EmailRequestReceiver {
         .addKeyValue("packCode", emailRequest.getPackCode())
         .addKeyValue("messageId", emailRequestHeader.getMessageId())
         .addKeyValue("correlationId", emailRequestHeader.getCorrelationId())
-        .addKeyValue("processingTimeMillis", System.currentTimeMillis() - startTime);
+        .addKeyValue("processingTimeMillis", System.currentTimeMillis() - startTime)
+        .log();
   }
 
   private EventDTO buildEmailRequestEnrichedEvent(

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -83,5 +83,7 @@ email-request-enriched-delay: 0  # milliseconds
 logging:
   profile: DEV
   level:
-    root: INFO
+    root: INFO # NB: This must never be set to a lower level than INFO as it can leak data into logs
     com.google.cloud.spring.pubsub.integration.inbound.PubSubInboundChannelAdapter: ERROR
+    uk.gov.ons.ssdc.notifysvc.messaging.EmailRequestEnrichedReceiver: DEBUG # To show our debug timing logs
+    uk.gov.ons.ssdc.notifysvc.messaging.EmailRequestReceiver: DEBUG # To show our debug timing logs


### PR DESCRIPTION
# Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We need to see the timings of our email request (and enriched email request) processing to understand duplication bugs. This will generate substantially more log noise, but at the debug level, so it can easily be filtered out or switched off.

The timing measurement is crude, but we are trying to understand performance characteristics over potentially tens of seconds due to thread starvation, we are not concerned with millisecond precision, so it should suffice.

# What has changed
<!--- What code changes has been made -->
<!--- Has there been any refactoring -->
<!--- What tests have been written -->
- Add logging for beginning and end of processing email requests, including the case ID, message IDs and a crude timing within in the method.

# How to test?
<!--- Describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to see how your change affects other areas of the code, etc. -->
<!--- Are there any automated tests that mean changes don't need to be manually changed -->
Build and run locally, check the lines are logged as expected.

# Links
<!--- Add any links to issues (trello, github issues) -->
<!--- Links to any documentation -->
<!--- Links to any related PRs -->
https://jira.ons.gov.uk/browse/SDCSRM-689