### PR TITLE
SDCSRM-1127 Implement Rate Limiter

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestEnrichedReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestEnrichedReceiver.java
@@ -26,6 +26,12 @@ public class EmailRequestEnrichedReceiver {
   @Value("${email-request-enriched-delay}")
   private int emailRequestEnrichedDelay;
 
+  @Value("${errorhandeling.rate-limit-error-http-status}")
+  private int rateLimitErrorHttpStatus;
+
+  @Value("${errorhandeling.rate-limiter-exception-message}")
+  private String rateLimiterExceptionMessage;
+
   private static final Logger log = LoggerFactory.getLogger(EmailRequestEnrichedReceiver.class);
 
   private final EmailTemplateRepository emailTemplateRepository;
@@ -95,6 +101,9 @@ public class EmailRequestEnrichedReceiver {
           personalisationTemplateValues,
           event.getHeader().getCorrelationId().toString()); // Use the correlation ID as reference
     } catch (NotificationClientException e) {
+      if (e.getHttpResult() == rateLimitErrorHttpStatus) {
+        throw new RuntimeException(rateLimiterExceptionMessage, e);
+      }
       throw new RuntimeException(
           "Error with Gov Notify when attempting to send email (from enriched email request event)",
           e);

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestEnrichedReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestEnrichedReceiver.java
@@ -102,7 +102,8 @@ public class EmailRequestEnrichedReceiver {
           event.getHeader().getCorrelationId().toString()); // Use the correlation ID as reference
     } catch (NotificationClientException e) {
       if (e.getHttpResult() == rateLimitErrorHttpStatus) {
-        throw new RuntimeException(rateLimiterExceptionMessage, e);
+        throw new RuntimeException(
+            rateLimiterExceptionMessage + " email (from enriched email request event)", e);
       }
       throw new RuntimeException(
           "Error with Gov Notify when attempting to send email (from enriched email request event)",

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestEnrichedReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestEnrichedReceiver.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ssdc.notifysvc.messaging;
 
+import static uk.gov.ons.ssdc.notifysvc.utils.Constants.RATE_LIMITER_EXCEPTION_MESSAGE;
+import static uk.gov.ons.ssdc.notifysvc.utils.Constants.RATE_LIMIT_ERROR_HTTP_STATUS;
 import static uk.gov.ons.ssdc.notifysvc.utils.JsonHelper.convertJsonBytesToEvent;
 import static uk.gov.ons.ssdc.notifysvc.utils.PersonalisationTemplateHelper.buildPersonalisationFromTemplate;
 
@@ -25,12 +27,6 @@ public class EmailRequestEnrichedReceiver {
 
   @Value("${email-request-enriched-delay}")
   private int emailRequestEnrichedDelay;
-
-  @Value("${errorhandling.rate-limit-error-http-status}")
-  private int rateLimitErrorHttpStatus;
-
-  @Value("${errorhandling.rate-limiter-exception-message}")
-  private String rateLimiterExceptionMessage;
 
   private static final Logger log = LoggerFactory.getLogger(EmailRequestEnrichedReceiver.class);
 
@@ -101,9 +97,9 @@ public class EmailRequestEnrichedReceiver {
           personalisationTemplateValues,
           event.getHeader().getCorrelationId().toString()); // Use the correlation ID as reference
     } catch (NotificationClientException e) {
-      if (e.getHttpResult() == rateLimitErrorHttpStatus) {
+      if (e.getHttpResult() == RATE_LIMIT_ERROR_HTTP_STATUS) {
         throw new RuntimeException(
-            rateLimiterExceptionMessage + " email (from enriched email request event)", e);
+            RATE_LIMITER_EXCEPTION_MESSAGE + " email (from enriched email request event)", e);
       }
       throw new RuntimeException(
           "Error with Gov Notify when attempting to send email (from enriched email request event)",

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/ManagedMessageRecoverer.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/ManagedMessageRecoverer.java
@@ -173,13 +173,13 @@ public class ManagedMessageRecoverer implements RecoveryCallback<Object> {
             .setCause(cause)
             .addKeyValue("message_hash", messageHash)
             .log();
-        return;
+      } else {
+        log.atError()
+            .setMessage("Could not process message")
+            .setCause(cause)
+            .addKeyValue("message_hash", messageHash)
+            .log();
       }
-      log.atError()
-          .setMessage("Could not process message")
-          .setCause(cause)
-          .addKeyValue("message_hash", messageHash)
-          .log();
     } else {
       // Having a separate event for when we are rate limited - makes it easier to track
       if (cause.getCause() != null
@@ -191,14 +191,14 @@ public class ManagedMessageRecoverer implements RecoveryCallback<Object> {
             .addKeyValue("root_cause", stackTraceRootCause)
             .addKeyValue("message_hash", messageHash)
             .log();
-        return;
+      } else {
+        log.atError()
+            .setMessage("Could not process message")
+            .addKeyValue("cause", cause.getMessage())
+            .addKeyValue("root_cause", stackTraceRootCause)
+            .addKeyValue("message_hash", messageHash)
+            .log();
       }
-      log.atError()
-          .setMessage("Could not process message")
-          .addKeyValue("cause", cause.getMessage())
-          .addKeyValue("root_cause", stackTraceRootCause)
-          .addKeyValue("message_hash", messageHash)
-          .log();
     }
   }
 

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/ManagedMessageRecoverer.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/ManagedMessageRecoverer.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ssdc.notifysvc.messaging;
 
+import static uk.gov.ons.ssdc.notifysvc.utils.Constants.RATE_LIMITER_EXCEPTION_MESSAGE;
+
 import com.google.cloud.spring.pubsub.support.BasicAcknowledgeablePubsubMessage;
 import com.google.cloud.spring.pubsub.support.GcpPubSubHeaders;
 import com.google.protobuf.ByteString;
@@ -25,9 +27,6 @@ public class ManagedMessageRecoverer implements RecoveryCallback<Object> {
 
   @Value("${messagelogging.logstacktraces}")
   private boolean logStackTraces;
-
-  @Value("${errorhandling.rate-limiter-exception-message}")
-  private String rateLimiterExceptionMessage;
 
   private final ExceptionManagerClient exceptionManagerClient;
 
@@ -167,7 +166,7 @@ public class ManagedMessageRecoverer implements RecoveryCallback<Object> {
       // Having a separate event for when we are rate limited - makes it easier to track
       if (cause.getCause() != null
           && cause.getCause().getMessage() != null
-          && cause.getCause().getMessage().contains(rateLimiterExceptionMessage)) {
+          && cause.getCause().getMessage().contains(RATE_LIMITER_EXCEPTION_MESSAGE)) {
         log.atError()
             .setMessage("Could not process message - rate limited")
             .setCause(cause)
@@ -184,7 +183,7 @@ public class ManagedMessageRecoverer implements RecoveryCallback<Object> {
       // Having a separate event for when we are rate limited - makes it easier to track
       if (cause.getCause() != null
           && cause.getCause().getMessage() != null
-          && cause.getCause().getMessage().contains(rateLimiterExceptionMessage)) {
+          && cause.getCause().getMessage().contains(RATE_LIMITER_EXCEPTION_MESSAGE)) {
         log.atError()
             .setMessage("Could not process message - rate limited")
             .addKeyValue("cause", cause.getMessage())

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/SmsRequestEnrichedReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/SmsRequestEnrichedReceiver.java
@@ -1,5 +1,7 @@
 package uk.gov.ons.ssdc.notifysvc.messaging;
 
+import static uk.gov.ons.ssdc.notifysvc.utils.Constants.RATE_LIMITER_EXCEPTION_MESSAGE;
+import static uk.gov.ons.ssdc.notifysvc.utils.Constants.RATE_LIMIT_ERROR_HTTP_STATUS;
 import static uk.gov.ons.ssdc.notifysvc.utils.JsonHelper.convertJsonBytesToEvent;
 import static uk.gov.ons.ssdc.notifysvc.utils.PersonalisationTemplateHelper.buildPersonalisationFromTemplate;
 
@@ -23,12 +25,6 @@ public class SmsRequestEnrichedReceiver {
 
   @Value("${sms-request-enriched-delay}")
   private int smsRequestEnrichedDelay;
-
-  @Value("${errorhandling.rate-limit-error-http-status}")
-  private int rateLimitErrorHttpStatus;
-
-  @Value("${errorhandling.rate-limiter-exception-message}")
-  private String rateLimiterExceptionMessage;
 
   private final SmsTemplateRepository smsTemplateRepository;
   private final CaseRepository caseRepository;
@@ -88,9 +84,9 @@ public class SmsRequestEnrichedReceiver {
           personalisationTemplateValues,
           senderId);
     } catch (NotificationClientException e) {
-      if (e.getHttpResult() == rateLimitErrorHttpStatus) {
+      if (e.getHttpResult() == RATE_LIMIT_ERROR_HTTP_STATUS) {
         throw new RuntimeException(
-            rateLimiterExceptionMessage + " SMS (from enriched SMS request event)", e);
+            RATE_LIMITER_EXCEPTION_MESSAGE + " SMS (from enriched SMS request event)", e);
       }
       throw new RuntimeException(
           "Error with Gov Notify when attempting to send SMS (from enriched SMS request event)", e);

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/SmsRequestEnrichedReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/SmsRequestEnrichedReceiver.java
@@ -24,6 +24,12 @@ public class SmsRequestEnrichedReceiver {
   @Value("${sms-request-enriched-delay}")
   private int smsRequestEnrichedDelay;
 
+  @Value("${errorhandeling.rate-limit-error-http-status}")
+  private int rateLimitErrorHttpStatus;
+
+  @Value("${errorhandeling.rate-limiter-exception-message}")
+  private String rateLimiterExceptionMessage;
+
   private final SmsTemplateRepository smsTemplateRepository;
   private final CaseRepository caseRepository;
   private final NotifyServiceRefMapping notifyServiceRefMapping;
@@ -82,6 +88,10 @@ public class SmsRequestEnrichedReceiver {
           personalisationTemplateValues,
           senderId);
     } catch (NotificationClientException e) {
+      if (e.getHttpResult() == rateLimitErrorHttpStatus) {
+        throw new RuntimeException(
+            rateLimiterExceptionMessage + " SMS (from enriched SMS request event)", e);
+      }
       throw new RuntimeException(
           "Error with Gov Notify when attempting to send SMS (from enriched SMS request event)", e);
     }

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/utils/Constants.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/utils/Constants.java
@@ -10,4 +10,7 @@ public class Constants {
   public static final String TEMPLATE_QID_KEY = "__qid__";
   public static final String TEMPLATE_SENSITIVE_PREFIX = "__sensitive__.";
   public static final String TEMPLATE_REQUEST_PREFIX = "__request__.";
+  public static final String RATE_LIMITER_EXCEPTION_MESSAGE =
+      "Error: Rate limit exceeded when trying attempting to send";
+  public static final int RATE_LIMIT_ERROR_HTTP_STATUS = 429;
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -77,8 +77,12 @@ management:
 messagelogging:
   logstacktraces: false
 
-sms-request-enriched-delay: 0  # milliseconds
-email-request-enriched-delay: 0  # milliseconds
+sms-request-enriched-delay: 50  # milliseconds
+email-request-enriched-delay: 50  # milliseconds
+
+errorhandeling:
+  rate-limit-error-http-status: 429
+  rate-limiter-exception-message: "Error: Rate limit exceeded when trying attempting to send email (from enriched email request event)"
 
 logging:
   profile: DEV

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -82,7 +82,7 @@ email-request-enriched-delay: 50  # milliseconds
 
 errorhandeling:
   rate-limit-error-http-status: 429
-  rate-limiter-exception-message: "Error: Rate limit exceeded when trying attempting to send email (from enriched email request event)"
+  rate-limiter-exception-message: "Error: Rate limit exceeded when trying attempting to send"
 
 logging:
   profile: DEV

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -80,10 +80,6 @@ messagelogging:
 sms-request-enriched-delay: 50  # milliseconds
 email-request-enriched-delay: 50  # milliseconds
 
-errorhandling:
-  rate-limit-error-http-status: 429
-  rate-limiter-exception-message: "Error: Rate limit exceeded when trying attempting to send"
-
 logging:
   profile: DEV
   level:

--- a/src/test/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestEnrichedReceiverTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestEnrichedReceiverTest.java
@@ -7,6 +7,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 import static uk.gov.ons.ssdc.notifysvc.testUtils.MessageConstructor.buildEventDTO;
 import static uk.gov.ons.ssdc.notifysvc.testUtils.MessageConstructor.constructMessageWithValidTimeStamp;
+import static uk.gov.ons.ssdc.notifysvc.utils.Constants.RATE_LIMITER_EXCEPTION_MESSAGE;
+import static uk.gov.ons.ssdc.notifysvc.utils.Constants.RATE_LIMIT_ERROR_HTTP_STATUS;
 import static uk.gov.ons.ssdc.notifysvc.utils.Constants.TEMPLATE_QID_KEY;
 import static uk.gov.ons.ssdc.notifysvc.utils.Constants.TEMPLATE_REQUEST_PREFIX;
 import static uk.gov.ons.ssdc.notifysvc.utils.Constants.TEMPLATE_UAC_KEY;
@@ -244,7 +246,7 @@ class EmailRequestEnrichedReceiverTest {
 
     Field field = NotificationClientException.class.getDeclaredField("httpResult");
     field.setAccessible(true);
-    field.set(notificationClientException, 429);
+    field.set(notificationClientException, RATE_LIMIT_ERROR_HTTP_STATUS);
 
     when(notificationClient.sendEmail(any(), any(), any(), any()))
         .thenThrow(notificationClientException);
@@ -255,8 +257,7 @@ class EmailRequestEnrichedReceiverTest {
             RuntimeException.class,
             () -> emailRequestEnrichedReceiver.receiveMessage(eventMessage));
     assertThat(thrown.getMessage())
-        .isEqualTo(
-            "Error with Gov Notify when attempting to send email (from enriched email request event)");
+        .isEqualTo(RATE_LIMITER_EXCEPTION_MESSAGE + " email (from enriched email request event)");
   }
 
   @Test

--- a/src/test/java/uk/gov/ons/ssdc/notifysvc/messaging/ManagedMessageRecovererTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/notifysvc/messaging/ManagedMessageRecovererTest.java
@@ -16,6 +16,7 @@ import com.google.cloud.spring.pubsub.support.BasicAcknowledgeablePubsubMessage;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PubsubMessage;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -27,6 +28,7 @@ import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.MessagingException;
 import org.springframework.retry.RetryContext;
+import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.ons.ssdc.notifysvc.client.ExceptionManagerClient;
 import uk.gov.ons.ssdc.notifysvc.model.dto.api.ExceptionReportResponse;
 import uk.gov.ons.ssdc.notifysvc.model.dto.api.SkippedMessage;
@@ -41,6 +43,12 @@ class ManagedMessageRecovererTest {
   @Mock private ExceptionManagerClient exceptionManagerClient;
 
   @InjectMocks private ManagedMessageRecoverer underTest;
+
+  @BeforeEach
+  public void setup() {
+    ReflectionTestUtils.setField(
+        underTest, "rateLimiterExceptionMessage", "TEST RATE LIMITER MESSAGE");
+  }
 
   @Test
   public void testRecover() {

--- a/src/test/java/uk/gov/ons/ssdc/notifysvc/messaging/ManagedMessageRecovererTest.java
+++ b/src/test/java/uk/gov/ons/ssdc/notifysvc/messaging/ManagedMessageRecovererTest.java
@@ -16,7 +16,6 @@ import com.google.cloud.spring.pubsub.support.BasicAcknowledgeablePubsubMessage;
 import com.google.protobuf.ByteString;
 import com.google.pubsub.v1.ProjectSubscriptionName;
 import com.google.pubsub.v1.PubsubMessage;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -28,7 +27,6 @@ import org.springframework.messaging.MessageHandlingException;
 import org.springframework.messaging.MessageHeaders;
 import org.springframework.messaging.MessagingException;
 import org.springframework.retry.RetryContext;
-import org.springframework.test.util.ReflectionTestUtils;
 import uk.gov.ons.ssdc.notifysvc.client.ExceptionManagerClient;
 import uk.gov.ons.ssdc.notifysvc.model.dto.api.ExceptionReportResponse;
 import uk.gov.ons.ssdc.notifysvc.model.dto.api.SkippedMessage;
@@ -43,12 +41,6 @@ class ManagedMessageRecovererTest {
   @Mock private ExceptionManagerClient exceptionManagerClient;
 
   @InjectMocks private ManagedMessageRecoverer underTest;
-
-  @BeforeEach
-  public void setup() {
-    ReflectionTestUtils.setField(
-        underTest, "rateLimiterExceptionMessage", "TEST RATE LIMITER MESSAGE");
-  }
 
   @Test
   public void testRecover() {


### PR DESCRIPTION
# Motivation and Context
Gov Notify are adding a rate limiter on their API, so we want to reduce the rate at which we send requests.

# What has changed
- Changed the delay from 0 to 50ms
- Added a error handling around rate limiting so a different error thrown as well as a different error log (This makes it easier to catch the error).
- Added a unit test
The unit test is not ideal, as I had to access a private field in Gov notify's `NotificationClientException` class. For some reason the constructor that includes the httpStatus is package-private and there's no setter for the field, meaning I had to do a janky work around that should only be done in testing.
I also had to set a test value for the error string to prevent a null pointer exception.

## Performance Testing
I ran a performance test with Case Processor and Notify Service set to the same resources and replicas as a PROD env.
I loaded a sample file with 50,000 participants and ran an email action rule:
**With rate limiter:**
Total Time: 10mins

**Without:**
Total Time: 3mins 

# How to test?
Run `make build` and the tests should pass.
I have made a test branch for ssdc-rm-notify-stub that will always return 429 (https://github.com/ONSdigital/ssdc-rm-notify-stub/tree/test-rate-limit-email), so run against that and you should see the errors.

# Links
[SDCSRM-1127](https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1127)

# Screenshots (if appropriate):
