### PR TITLE
Bump ssdc-rm-common-entity-model to 4.24.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
 		<dependency>
 			<groupId>uk.gov.ons.ssdc</groupId>
 			<artifactId>ssdc-rm-common-entity-model</artifactId>
-			<version>4.23.2</version>
+			<version>4.24.0</version>
 		</dependency>
 		<dependency>
 			<groupId>uk.gov.ons.ssdc</groupId>


### PR DESCRIPTION
# Motivation and Context
Bump entity model to pick up new MI snapshot tables (mi_email_request, mi_export_file_request, mi_response_rate) from DDL v1.4.0.

# What has changed
- Updated ssdc-rm-common-entity-model version from 4.23.2 to 4.24.0 in pom.xml

# How to test?
CI build should pass — no code changes, just a dependency version bump.

# Links
- DDL PR: https://github.com/ONSdigital/ssdc-rm-ddl/pull/236