### PR TITLE
SDCSRM-1590: improve UAC/QID generation logs

### DIFF
--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/client/UacQidServiceClient.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/client/UacQidServiceClient.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponents;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -26,17 +27,31 @@ public class UacQidServiceClient {
   private static final Logger log = LoggerFactory.getLogger(UacQidServiceClient.class);
 
   public UacQidCreatedPayloadDTO generateUacQid() {
-    log.atError()
-        .setMessage("HTTP call to generate a UAC and QID")
-        .addKeyValue("method", "generateUacQid")
-        .log();
+    long startTime = System.currentTimeMillis();
 
     RestTemplate restTemplate = new RestTemplate();
     UriComponents uriComponents = createUriComponents();
-    ResponseEntity<UacQidCreatedPayloadDTO> responseEntity =
-        restTemplate.exchange(
-            uriComponents.toUri(), HttpMethod.GET, null, UacQidCreatedPayloadDTO.class);
-    return responseEntity.getBody();
+    try {
+      ResponseEntity<UacQidCreatedPayloadDTO> responseEntity =
+          restTemplate.exchange(
+              uriComponents.toUri(), HttpMethod.GET, null, UacQidCreatedPayloadDTO.class);
+
+      log.atInfo()
+          .setMessage("Finished UAC/QID generation HTTP request")
+          .addKeyValue("method", "generateUacQid")
+          .addKeyValue("processingTimeMillis", System.currentTimeMillis() - startTime)
+          .log();
+
+      return responseEntity.getBody();
+    } catch (RestClientException e) {
+      log.atError()
+          .setMessage("Error generating UAC/QID")
+          .addKeyValue("method", "generateUacQid")
+          .addKeyValue("processingTimeMillis", System.currentTimeMillis() - startTime)
+          .setCause(e)
+          .log();
+      throw e;
+    }
   }
 
   private UriComponents createUriComponents() {

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/endpoint/EmailFulfilmentEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/endpoint/EmailFulfilmentEndpoint.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ssdc.notifysvc.endpoint;
 
 import static uk.gov.ons.ssdc.notifysvc.utils.PersonalisationTemplateHelper.buildPersonalisationFromTemplate;
+import static uk.gov.ons.ssdc.notifysvc.utils.PersonalisationTemplateHelper.doesTemplateRequireNewUacQid;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -102,6 +103,16 @@ public class EmailFulfilmentEndpoint {
       return new ResponseEntity<>(
           new EmailFulfilmentResponseError(responseStatusException.getReason()),
           responseStatusException.getStatusCode());
+    }
+
+    if (doesTemplateRequireNewUacQid(emailTemplate.getTemplate())) {
+      log.atInfo()
+          .setMessage("Generating UAC/QID for email fulfilment request")
+          .addKeyValue("method", "generateUacQid")
+          .addKeyValue("caseId", request.getPayload().getEmailFulfilment().getCaseId())
+          .addKeyValue("packCode", request.getPayload().getEmailFulfilment().getPackCode())
+          .addKeyValue("correlationId", request.getHeader().getCorrelationId())
+          .log();
     }
 
     Optional<UacQidCreatedPayloadDTO> newUacQidPair =

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/endpoint/SmsFulfilmentEndpoint.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/endpoint/SmsFulfilmentEndpoint.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ssdc.notifysvc.endpoint;
 
 import static uk.gov.ons.ssdc.notifysvc.utils.PersonalisationTemplateHelper.buildPersonalisationFromTemplate;
+import static uk.gov.ons.ssdc.notifysvc.utils.PersonalisationTemplateHelper.doesTemplateRequireNewUacQid;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -102,6 +103,16 @@ public class SmsFulfilmentEndpoint {
       return new ResponseEntity<>(
           new SmsFulfilmentResponseError(responseStatusException.getReason()),
           responseStatusException.getStatusCode());
+    }
+
+    if (doesTemplateRequireNewUacQid(smsTemplate.getTemplate())) {
+      log.atInfo()
+          .setMessage("Generating UAC/QID for SMS fulfilment request")
+          .addKeyValue("method", "generateUacQid")
+          .addKeyValue("caseId", request.getPayload().getSmsFulfilment().getCaseId())
+          .addKeyValue("packCode", request.getPayload().getSmsFulfilment().getPackCode())
+          .addKeyValue("correlationId", request.getHeader().getCorrelationId())
+          .log();
     }
 
     Optional<UacQidCreatedPayloadDTO> newUacQidPair =

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/EmailRequestReceiver.java
@@ -1,6 +1,7 @@
 package uk.gov.ons.ssdc.notifysvc.messaging;
 
 import static uk.gov.ons.ssdc.notifysvc.utils.JsonHelper.convertJsonBytesToEvent;
+import static uk.gov.ons.ssdc.notifysvc.utils.PersonalisationTemplateHelper.doesTemplateRequireNewUacQid;
 
 import java.time.OffsetDateTime;
 import java.util.Optional;
@@ -82,6 +83,17 @@ public class EmailRequestReceiver {
 
     if (!caseRepository.existsById(emailRequest.getCaseId())) {
       throw new RuntimeException("Case not found with ID: " + emailRequest.getCaseId());
+    }
+
+    if (doesTemplateRequireNewUacQid(emailTemplate.getTemplate())) {
+      log.atInfo()
+          .setMessage("Generating UAC/QID for email request")
+          .addKeyValue("method", "generateUacQid")
+          .addKeyValue("caseId", emailRequest.getCaseId())
+          .addKeyValue("packCode", emailRequest.getPackCode())
+          .addKeyValue("messageId", emailRequestHeader.getMessageId())
+          .addKeyValue("correlationId", emailRequestHeader.getCorrelationId())
+          .log();
     }
 
     Optional<UacQidCreatedPayloadDTO> newUacQidPair =

--- a/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/SmsRequestReceiver.java
+++ b/src/main/java/uk/gov/ons/ssdc/notifysvc/messaging/SmsRequestReceiver.java
@@ -1,10 +1,13 @@
 package uk.gov.ons.ssdc.notifysvc.messaging;
 
 import static uk.gov.ons.ssdc.notifysvc.utils.JsonHelper.convertJsonBytesToEvent;
+import static uk.gov.ons.ssdc.notifysvc.utils.PersonalisationTemplateHelper.doesTemplateRequireNewUacQid;
 
 import java.time.OffsetDateTime;
 import java.util.Optional;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.integration.annotation.MessageEndpoint;
 import org.springframework.integration.annotation.ServiceActivator;
@@ -27,6 +30,8 @@ public class SmsRequestReceiver {
 
   @Value("${queueconfig.sms-request-enriched-topic}")
   private String smsRequestEnrichedTopic;
+
+  private static final Logger log = LoggerFactory.getLogger(SmsRequestReceiver.class);
 
   private final CaseRepository caseRepository;
   private final SmsTemplateRepository smsTemplateRepository;
@@ -62,6 +67,17 @@ public class SmsRequestReceiver {
 
     if (!caseRepository.existsById(smsRequest.getCaseId())) {
       throw new RuntimeException("Case not found with ID: " + smsRequest.getCaseId());
+    }
+
+    if (doesTemplateRequireNewUacQid(smsTemplate.getTemplate())) {
+      log.atInfo()
+          .setMessage("Generating UAC/QID for SMS request")
+          .addKeyValue("method", "generateUacQid")
+          .addKeyValue("caseId", smsRequest.getCaseId())
+          .addKeyValue("packCode", smsRequest.getPackCode())
+          .addKeyValue("messageId", smsRequestHeader.getMessageId())
+          .addKeyValue("correlationId", smsRequestHeader.getCorrelationId())
+          .log();
     }
 
     Optional<UacQidCreatedPayloadDTO> newUacQidPair =


### PR DESCRIPTION
# Motivation and Context
There are alerts raised by notify-service every time it sends messages (for example https://cloudlogging.app.goo.gl/bETGGUo237sDy1hN7).

The reason are debugging logs added in https://officefornationalstatistics.atlassian.net/browse/SDCSRM-862. As these are not really errors, they should be downgraded.

# What has changed
* Replaced the ERROR breadcrumb with new logs based on outcome. 
* Added processingTimeMillis to the context in case the need from SDCSRM-862 reoccurs.
* Added the case context as well.

# How to test?
Run `make test`. Existing tests should show new logs.

# Links
https://officefornationalstatistics.atlassian.net/browse/SDCSRM-1590